### PR TITLE
Specified full path to prevent errors

### DIFF
--- a/02_bonus/valgrind/Dockerfile
+++ b/02_bonus/valgrind/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get -y update &&\
 	apt-get install -y gcc make\
 	valgrind git vim
 
-COPY .vimrc /root
-COPY .zshrc /root
+COPY ~/.vimrc /root
+COPY ~/.zshrc /root
 
 USER root
 


### PR DESCRIPTION
Directory was not found without full path, causing Docker build to stop. Resolved this issue